### PR TITLE
Fix NPE in Logger if pattern does not match, default to INFO

### DIFF
--- a/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
@@ -103,9 +103,10 @@ public abstract class AbstractMkdocsMojo extends AbstractMojo {
         }
 
         try {
-            Process proc = new ProcessBuilder(args)
-                    .directory(basedir)
-                    .start();
+            ProcessBuilder pb = new ProcessBuilder(args)
+                    .directory(basedir);
+            pb.environment().put("NO_COLOR", "1");
+            Process proc = pb.start();
 
             MkdocsLogger logger = new MkdocsLogger(getLog());
 

--- a/src/main/java/org/shredzone/maven/mkdocs/MkdocsLogger.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/MkdocsLogger.java
@@ -24,10 +24,9 @@ import org.apache.maven.plugin.logging.Log;
  * Logs mkdocs output into the correct maven log level.
  */
 public class MkdocsLogger {
-    private static final Pattern LOG_PATTERN = Pattern.compile("^(DEBUG|INFO|WARNING|ERROR)\\s+-\\s+(.*)$");
+    private static final Pattern LOG_PATTERN = Pattern.compile("^(Traceback|DEBUG|INFO|WARNING|ERROR)\\s+-\\s+(.*)$");
 
     private final Log log;
-    private String lastLevel;
 
     /**
      * Creates a new {@link MkdocsLogger}.
@@ -47,18 +46,15 @@ public class MkdocsLogger {
      */
     public void log(String line) {
         String message = line;
+        String level = "INFO";
 
-        if (line.startsWith("Traceback")) {
-            lastLevel = "TRACEBACK";
-        } else {
-            Matcher m = LOG_PATTERN.matcher(line);
-            if (m.matches()) {
-                lastLevel = m.group(1);
-                message = m.group(2);
-            }
+        Matcher m = LOG_PATTERN.matcher(line);
+        if (m.matches()) {
+            level = m.group(1);
+            message = m.group(2);
         }
 
-        switch (lastLevel) {
+        switch (level) {
             case "DEBUG":
                 log.debug(message);
                 break;


### PR DESCRIPTION
Hi *Shred*,

`mkdocs` is failing on pipeline, but the error is printed by CPython, so it's not the expected log line format, therefore `MkDocsLogger` fails with a NPE on line 61 because `lastLevel` is null (pattern does not match).
I've also refactored the code a little.

Thanks!