### PR TITLE
An ability to specify `mkdocs.toolPath` as a command with arguments and to define environment variables for it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+/.idea

--- a/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -62,6 +63,9 @@ public abstract class AbstractMkdocsMojo extends AbstractMojo {
      */
     @Parameter(property = "mkdocs.toolPath", defaultValue = "mkdocs")
     protected String mkdocsPath;
+
+    @Parameter(property = "mkdocs.environment")
+    protected Map<String, String> environmentVars;
 
     /**
      * Performs the mkdocs goal.
@@ -113,6 +117,10 @@ public abstract class AbstractMkdocsMojo extends AbstractMojo {
         try {
             ProcessBuilder pb = new ProcessBuilder(processArgs)
                     .directory(basedir);
+
+            if (environmentVars != null) {
+                pb.environment().putAll(environmentVars);
+            }
 
             pb.environment().put("NO_COLOR", "1");
             Process proc = pb.start();

--- a/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -98,13 +100,20 @@ public abstract class AbstractMkdocsMojo extends AbstractMojo {
      *         Base directory
      */
     protected void invokeMkdocs(List<String> args, File basedir) throws IOException {
+        final String[] mkdocsPathArgs =  mkdocsPath.split("\\s+");
+        final List<String> processArgs = new ArrayList<>();
+
+        processArgs.addAll(Arrays.asList(mkdocsPathArgs));
+        processArgs.addAll(args);
+
         if (getLog().isDebugEnabled()) {
-            getLog().debug(args.stream().collect(joining("' '", "'", "'")));
+            getLog().debug(processArgs.stream().collect(joining("' '", "'", "'")));
         }
 
         try {
-            ProcessBuilder pb = new ProcessBuilder(args)
+            ProcessBuilder pb = new ProcessBuilder(processArgs)
                     .directory(basedir);
+
             pb.environment().put("NO_COLOR", "1");
             Process proc = pb.start();
 

--- a/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/AbstractMkdocsMojo.java
@@ -64,6 +64,9 @@ public abstract class AbstractMkdocsMojo extends AbstractMojo {
     @Parameter(property = "mkdocs.toolPath", defaultValue = "mkdocs")
     protected String mkdocsPath;
 
+    /**
+     * The environment variables to be used when invoking mkdocs.
+     */
     @Parameter(property = "mkdocs.environment")
     protected Map<String, String> environmentVars;
 

--- a/src/main/java/org/shredzone/maven/mkdocs/MkdocsBuildMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/MkdocsBuildMojo.java
@@ -62,8 +62,8 @@ public class MkdocsBuildMojo extends AbstractMkdocsMojo {
 
     @Override
     protected void perform() throws IOException {
-        List<String> args = new ArrayList<>();
-        args.add(mkdocsPath);
+        final List<String> args = new ArrayList<>();
+
         args.add("build");
 
         if (getLog().isDebugEnabled()) {

--- a/src/main/java/org/shredzone/maven/mkdocs/MkdocsDeployMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/MkdocsDeployMojo.java
@@ -63,8 +63,8 @@ public class MkdocsDeployMojo extends AbstractMkdocsMojo {
 
     @Override
     protected void perform() throws IOException {
-        List<String> args = new ArrayList<>();
-        args.add(mkdocsPath);
+        final List<String> args = new ArrayList<>();
+
         args.add("gh-deploy");
 
         if (getLog().isDebugEnabled()) {

--- a/src/main/java/org/shredzone/maven/mkdocs/MkdocsServeMojo.java
+++ b/src/main/java/org/shredzone/maven/mkdocs/MkdocsServeMojo.java
@@ -67,8 +67,8 @@ public class MkdocsServeMojo extends AbstractMkdocsMojo {
 
     @Override
     protected void perform() throws IOException {
-        List<String> args = new ArrayList<>();
-        args.add(mkdocsPath);
+        final List<String> args = new ArrayList<>();
+
         args.add("serve");
 
         if (getLog().isDebugEnabled()) {
@@ -86,9 +86,10 @@ public class MkdocsServeMojo extends AbstractMkdocsMojo {
         }
 
         if (host != null || port != null) {
-            String addr = (host != null ? host : "localhost")
+            final String addr = (host != null ? host : "localhost")
                     + ":"
                     + (port != null ? port : 8000);
+
             args.add("--dev-addr");
             args.add(addr);
         }


### PR DESCRIPTION
This PR enhances the `mkdocs-maven-plugin` by introducing the following capabilities:

## Specify `mkdocs.toolPath` with Command Arguments
User can define `mkdocs.toolPath` as a command with arguments.

Example:
```xml
<configuration>
  <mkdocsPath>python3 -m mkdocs</mkdocsPath>
</configuration>
```

## Define Environment Variables:

Users can now define environment variables for the mkdocs command.

Example:
```xml
<configuration>
  <environmentVars>
    <PYTHONPATH>${project.build.directory}/python-deps</PYTHONPATH >
  </environmentVars>
</configuration>
```

## Impact:

This feature allows for greater flexibility in configuring how mkdocs is invoked, accommodating a range of environments and specific user needs. 

E.g. the mkdocs python dependencies could be installed in the project build directory and used from there. The only dependency required from the environment is `python`. 